### PR TITLE
product_purchase_confirmation

### DIFF
--- a/app/assets/stylesheets/_product_purchase_confirmation.scss
+++ b/app/assets/stylesheets/_product_purchase_confirmation.scss
@@ -1,0 +1,33 @@
+body{
+  .header-pp-confirmation{
+    a{
+      img{
+        display: block;
+        width: 14%;
+        margin: 2% auto;
+      }
+    }
+  }
+  .main-pp-confirmation{
+    width: 60%;
+    background-color: #fff;
+    margin: 0 auto;
+    &__top{
+      text-align: center;
+      padding: 2% 0 ;
+      border: 1px solid #f5f5f5;
+      p{
+        font-size: 21px;
+        font-weight: bold;
+      }
+    }
+    &__buttom{
+      margin: 0 0 20% 30%;
+      padding: 5% 0;
+      a{
+        color: #0099e8;
+        font-size: 14px;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,3 +15,4 @@
 @import "test";
 @import "nice";
 @import "topage";
+@import "product_purchase_confirmation"

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -11,5 +11,8 @@ class MainController < ApplicationController
 
   def show#商品詳細
   end
+
+  def product_purchase_confirmation #商品購入確認
+  end
   
 end

--- a/app/views/main/product_purchase_confirmation.html.haml
+++ b/app/views/main/product_purchase_confirmation.html.haml
@@ -1,22 +1,20 @@
-%head
-%body
-  .header-pp-confirmation
-    = link_to image_tag("https://www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?3580354878"),"https://www.mercari.com/jp/"
-  .main-pp-confirmation
-    .main-pp-confirmation__top
-      %p 商品は既に売り切れています
-    .main-pp-confirmation__buttom
-      =link_to "商品画面に戻る","https://item.mercari.com/jp/m70068440240/"
-  .footer.gray
-    %ul
-      %li
-        = link_to "プライバシーポリシー", "https://www.mercari.com/jp/privacy/"
-      %li
-        = link_to "メルカリ利用規約", "https://www.mercari.com/jp/tos/"
-      %li
-        = link_to "特定商取引に関する表記", "https://www.mercari.com/jp/tokutei/"
-    %br
-    %br
-    = link_to image_tag("https://www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?3580354878"), "https://www.mercari.com/jp/",{class:"single-footer-logo"}
-    .footer__bottom
-      %p © 2019 Mercari
+.header-pp-confirmation
+  = link_to image_tag("https://www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?3580354878"),"https://www.mercari.com/jp/"
+.main-pp-confirmation
+  .main-pp-confirmation__top
+    %p 商品は既に売り切れています
+  .main-pp-confirmation__buttom
+    =link_to "商品画面に戻る","https://item.mercari.com/jp/m70068440240/"
+.footer.gray
+  %ul
+    %li
+      = link_to "プライバシーポリシー", "https://www.mercari.com/jp/privacy/"
+    %li
+      = link_to "メルカリ利用規約", "https://www.mercari.com/jp/tos/"
+    %li
+      = link_to "特定商取引に関する表記", "https://www.mercari.com/jp/tokutei/"
+  %br
+  %br
+  = link_to image_tag("https://www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?3580354878"), "https://www.mercari.com/jp/",{class:"single-footer-logo"}
+  .footer__bottom
+    %p © 2019 Mercari

--- a/app/views/main/product_purchase_confirmation.html.haml
+++ b/app/views/main/product_purchase_confirmation.html.haml
@@ -1,0 +1,22 @@
+%head
+%body
+  .header-pp-confirmation
+    = link_to image_tag("https://www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?3580354878"),"https://www.mercari.com/jp/"
+  .main-pp-confirmation
+    .main-pp-confirmation__top
+      %p 商品は既に売り切れています
+    .main-pp-confirmation__buttom
+      =link_to "商品画面に戻る","https://item.mercari.com/jp/m70068440240/"
+  .footer.gray
+    %ul
+      %li
+        = link_to "プライバシーポリシー", "https://www.mercari.com/jp/privacy/"
+      %li
+        = link_to "メルカリ利用規約", "https://www.mercari.com/jp/tos/"
+      %li
+        = link_to "特定商取引に関する表記", "https://www.mercari.com/jp/tokutei/"
+    %br
+    %br
+    = link_to image_tag("https://www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?3580354878"), "https://www.mercari.com/jp/",{class:"single-footer-logo"}
+    .footer__bottom
+      %p © 2019 Mercari

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,10 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :main
+  resources :main do
+    collection do
+      get 'product_purchase_confirmation'
+    end
+  end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
what
商品購入確認ページviewの作成

why
商品購入後に完了を伝えるため

![image](https://user-images.githubusercontent.com/54707121/68686246-ad68db00-05ae-11ea-8c71-829df3e1f1e5.png)
